### PR TITLE
gradients are now correctly displayed in the diagnostics screen again

### DIFF
--- a/matlab/cnn_train_autonn.m
+++ b/matlab/cnn_train_autonn.m
@@ -460,8 +460,13 @@ w = net.getValue(paramVars) ;
 dw = net.getDer(paramVars) ;
 if isscalar(paramVars), w = {w} ; dw = {dw} ; end
 
-% allow memory to be released, for parameters and their derivatives
-net.setValue([paramVars, paramVars + 1], cell(1, 2 * numel(paramVars))) ;
+if ~params.plotDiagnostics
+  % allow memory to be released, for parameters and their derivatives
+  net.setValue([paramVars, paramVars + 1], cell(1, 2 * numel(paramVars))) ;
+else
+  % free only parameter memory, as we still need the gradients for plotting the diagnostics
+  net.setValue(paramVars, cell(size(paramVars))) ;
+end
 
 for p=1:numel(net.params)
   if ~isempty(parserv)


### PR DESCRIPTION
By deleting the gradients before calling the plotDiagnostics function, gradients are not shown in the diagnostics screen. This PR fixes the issue by freeing memory for the parameters only, but not their derivatives, if opts.plotDiagnostics is set to true.