### PR TITLE
enable anonymous postEpochFn

### DIFF
--- a/matlab/cnn_train_autonn.m
+++ b/matlab/cnn_train_autonn.m
@@ -191,7 +191,7 @@ for epoch=start+1:opts.numEpochs
   end
   
   if ~isempty(opts.postEpochFn)
-    if nargout(opts.postEpochFn) == 0
+    if nargout(opts.postEpochFn) <= 0
       opts.postEpochFn(net, params, state) ;
     else
       lr = opts.postEpochFn(net, params, state) ;


### PR DESCRIPTION
small change to allow postEpochFn to have nargout -1.  This is useful if you want to use something like `opts.postEpochFn = @(x,y,z) f(x,y,z,opts)`.