### PR TITLE
Added forward and backward pass timing to net struct

### DIFF
--- a/matlab/@Net/Net.m
+++ b/matlab/@Net/Net.m
@@ -46,6 +46,8 @@ classdef Net < handle
     gpu = false  % whether the network is in GPU or CPU mode
     isGpuVar = []  % whether each variable or derivative can be on the GPU
     parameterServer = []  % ParameterServer object, accumulates parameter derivatives across GPUs
+    forwardTime = [] % forward pass function timing
+    backwardTime = [] % backward pass function timing
   end
   properties (SetAccess = public, GetAccess = public)
     meta = []  % optional meta properties

--- a/matlab/@Net/eval.m
+++ b/matlab/@Net/eval.m
@@ -83,7 +83,9 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
     args(layer.inputArgPos) = vars(layer.inputVars) ;
     
     out = cell(1, max(layer.outputArgPos)) ;
+    time = tic;
     [out{:}] = layer.func(args{:}) ;
+    net.forwardTime(k) = toc(time);
     
     vars(layer.outputVar) = out(layer.outputArgPos);
   end
@@ -114,7 +116,9 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
       if ~isequal(layer.func, @slice_wrapper)
         % call function and collect outputs
         out = cell(1, layer.numInputDer) ;
+        time = tic;
         [out{:}] = layer.func(args{:}) ;
+        net.backwardTime(k) = toc(time);
 
         % sum derivatives. the derivative var corresponding to each
         % input comes right next to it in the vars list. note that some


### PR DESCRIPTION
This is a simple change to get similar forward and backward pass times like with dagnn which I could not find currently in autonn. 

Or would these results better go inside the net.forward and net.backward struct arrays ? 

I havent used autonn much yet but hopefully this is the right kind of changes to match the rest of the code.

