### PR TITLE
added breakpoints at layers

### DIFF
--- a/matlab/@Layer/Layer.m
+++ b/matlab/@Layer/Layer.m
@@ -84,6 +84,7 @@ classdef Layer < matlab.mixin.Copyable
     source = []  % call stack (source files and line numbers) where this Layer was created
     diagnostics = []  % whether to plot the mean, min and max of the Layer's output var. empty for automatic (network outputs only).
     optimize = []  % whether to optimize this Layer (e.g. merge vl_nnwsum), empty for function-dependent default
+    debugStop = false % call `keyboard` during forward pass
   end
   
   properties (SetAccess = {?Net}, GetAccess = public)

--- a/matlab/@Net/compile.m
+++ b/matlab/@Net/compile.m
@@ -63,7 +63,8 @@ function compile(net, varargin)
 
   % allocate memory
   net.forward = Net.initStruct(numel(idx), 'func', 'name', ...
-      'source', 'args', 'inputVars', 'inputArgPos', 'outputVar', 'outputArgPos') ;
+      'source', 'args', 'inputVars', 'inputArgPos', 'outputVar', 'outputArgPos', ...
+      'debugStop') ;
   net.backward = Net.initStruct(numel(idx), 'func', 'name', ...
       'source', 'args', 'inputVars', 'inputArgPos', 'numInputDer', 'accumDer') ;
 
@@ -137,6 +138,7 @@ function compile(net, varargin)
     layer.source = obj.source ;
     layer.outputArgPos = find(obj.outputVar ~= 0) ;  % skip unused outputs
     layer.outputVar = obj.outputVar(layer.outputArgPos) ;
+    layer.debugStop = obj.debugStop ;
     net.forward(k) = Net.parseArgs(layer, obj.inputs) ;
   end
 

--- a/matlab/@Net/eval.m
+++ b/matlab/@Net/eval.m
@@ -86,10 +86,12 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
       layer = forward(k) ;
       args = layer.args ;
       args(layer.inputArgPos) = vars(layer.inputVars) ;
-
       out = cell(1, max(layer.outputArgPos)) ;
+      if isfield(layer,'debugStop') && layer.debugStop
+        fprintf('debug stop at layer %s ...\n',layer.name);
+        keyboard
+      end
       [out{:}] = layer.func(args{:}) ;
-
       vars(layer.outputVar) = out(layer.outputArgPos);
     end
   end


### PR DESCRIPTION
During network construction, a user sets the "debugStop" property of a given Layer object to "true". After compiling, the graph execution stops with a "keyboard" command at the given layer. 