### PR TITLE
delete intermediate derivatives for memory savings

### DIFF
--- a/matlab/@Net/Net.m
+++ b/matlab/@Net/Net.m
@@ -50,6 +50,7 @@ classdef Net < handle
   properties (SetAccess = public, GetAccess = public)
     meta = []  % optional meta properties
     diagnostics = []  % list of diagnosed vars (see Net.plotDiagnostics)
+    conserveMemory = 0
   end
 
   methods (Access = private)

--- a/matlab/@Net/eval.m
+++ b/matlab/@Net/eval.m
@@ -164,6 +164,14 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
           vars{inputDer} = vars{inputDer} + slice_der(args{:}) ;
         end
       end
+      
+      % this derivative is no longer need, remove it to conserve memory
+      if net.conserveMemory
+          if numel(layer.inputVars)
+            vars{layer.inputVars(end)} = [];
+          end
+      end
+      
     end
   end
 

--- a/matlab/@Net/eval.m
+++ b/matlab/@Net/eval.m
@@ -78,6 +78,7 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
   % use local variables for efficiency
   forward = net.forward ;
   vars = net.vars ;
+  conserveMemory = net.conserveMemory;
   net.vars = {} ;  % allows Matlab to release memory when needed
 
   % forward pass
@@ -165,13 +166,18 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
         end
       end
       
-      % this derivative is no longer need, remove it to conserve memory
-      if net.conserveMemory
-          if numel(layer.inputVars)
-            vars{layer.inputVars(end)} = [];
-          end
-      end
-      
+      % remove derivatives (even input vars)
+      % as they are no longer used in the network
+    if conserveMemory
+        for i = numel(layer.inputVars):-1:1
+            if ~mod(layer.inputVars(i),2)
+                vars{layer.inputVars(end)} = [];
+            else
+                break;
+            end
+        end
+    end
+
     end
   end
 

--- a/matlab/@Net/eval.m
+++ b/matlab/@Net/eval.m
@@ -169,13 +169,8 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
       % remove derivatives (even input vars)
       % as they are no longer used in the network
     if conserveMemory
-        for i = numel(layer.inputVars):-1:1
-            if ~mod(layer.inputVars(i),2)
-                vars{layer.inputVars(end)} = [];
-            else
-                break;
-            end
-        end
+        idx = ~mod(layer.inputVars,2);
+        vars(layer.inputVars(idx)) = {[]};
     end
 
     end


### PR DESCRIPTION
adds a conserveMemory property to Net, similar to MatConvNet dagnn, specifically for the
deletion of intermediate derivatives during back prop. 