### PR TITLE
repelem shiftdim and complex abs

### DIFF
--- a/matlab/@Layer/Layer.m
+++ b/matlab/@Layer/Layer.m
@@ -219,11 +219,18 @@ classdef Layer < matlab.mixin.Copyable
       y = Layer(@repmat, obj, varargin{:}) ;
       y.numInputDer = 1 ;  % only the first derivative is defined
     end
+    function y = repelem(obj,varargin)
+      y = Layer(@repelem,obj,varargin{:});
+      y.numInputDer = 1 ;  % only the first derivative is defined
+    end
     function y = permute(obj, varargin)
       y = Layer(@permute, obj, varargin{:}) ;
     end
     function y = ipermute(obj, varargin)
       y = Layer(@ipermute, obj, varargin{:}) ;
+    end
+    function y = shiftdim(obj, varargin)
+      y = Layer(@permute, obj, varargin{:}) ;
     end
     function y = squeeze(obj, varargin)
       y = Layer(@squeeze, obj, varargin{:}) ;

--- a/matlab/derivatives/autonn_der.m
+++ b/matlab/derivatives/autonn_der.m
@@ -33,6 +33,17 @@ function dx = reshape_der(x, varargin)  %#ok<*DEFNU>
   end
 end
 
+function dx = shiftdim_der(x, varargin) 
+  dy = varargin{end} ;
+  if isscalar(dy) && dy == 0  % special case, no derivative
+    dx = zeros(size(x), 'like', x) ;
+  elseif numel(varargin) == 1 % remove singelton behavior y = shiftdim(x);
+    dx = reshape(dy,size(x)); % re add singeltons
+  else
+    dx = shiftdim(dy,-varargin{2}); % unshift dimensions
+  end
+end
+
 function dx = permute_der(x, dim, dy)
   if isscalar(dy) && dy == 0  % special case, no derivative
     dx = zeros(size(x), 'like', x) ;

--- a/matlab/derivatives/autonn_der.m
+++ b/matlab/derivatives/autonn_der.m
@@ -40,7 +40,13 @@ function dx = shiftdim_der(x, varargin)
   elseif numel(varargin) == 1 % remove singelton behavior y = shiftdim(x);
     dx = reshape(dy,size(x)); % re add singeltons
   else
-    dx = shiftdim(dy,-varargin{2}); % unshift dimensions
+    n = varargin{1};
+    if n<0
+      dx = reshape(dy,size(x)); % remove singletons
+    else
+      n = mod(n,ndims(x));
+      dx = ipermute(dy,[n+1:ndims(x),1:n]); %unshift
+    end
   end
 end
 

--- a/matlab/derivatives/autonn_der.m
+++ b/matlab/derivatives/autonn_der.m
@@ -112,10 +112,18 @@ function dx = circshift_der(x, k, dim, dy)
   end
 end
 
-
 function dx = abs_der(x, dy)
-  assert(isreal(dy), 'Complex values not supported by ABS derivative.') ;
-  dx = dy .* sign(x) ;
+  if isreal(x)
+    dx = dy .* sign(x) ;
+  else
+    x_re = real(x);
+    x_im = imag(x);
+    mag = x_re.^2 + x_im.^2; 
+    dy = (.5)*dy.*mag.^(-.5); % dx of sqrt
+    dx_re = 2*dy.*x_re; % dx of .^2
+    dx_im = 2*dy.*x_im;
+    dx = dx_re + dx_im*sqrt(-1); % make deriv complex
+  end
 end
 
 function dx = sqrt_der(x, dy)

--- a/matlab/derivatives/repelem_der.m
+++ b/matlab/derivatives/repelem_der.m
@@ -1,0 +1,46 @@
+function dx = repelem_der(x,varargin)
+%REPELEM_DER
+%   REPELEM_DER(X, N, DZDY)
+%   REPELEM_DER(X, D1, D2, ..., DZDY)
+%   Derivative of REPELEM function, w.r.t. first input. Same syntax as
+%   native REPELEM, plus derivative.
+
+% Copyright (C) 2017 Joao F. Henriques, Ryan Webster
+% All rights reserved.
+%
+% This file is part of the VLFeat library and is made available under
+% the terms of the BSD license (see the COPYING file).
+
+  dy = varargin{end};
+
+  % NOTE: repelem and repmat have a difference in behavior
+  % for vector / scalar input 
+  if isvector(x) % u = repelem(v,n) behavior
+    n = varargin{1};
+    % repeated dim is nonsingleton dimension
+    rep_dim = find(size(x)~=1);
+    if rep_dim == 1
+      repelem_sz = [n,1];
+    else
+      % rep_dim == 2 or x is scalar
+      % either way the repeated dim is 2
+      repelem_sz = [1,n];
+    end
+  else % B = repelem(A,r1,...,rN) behavior
+    repelem_sz = cell2mat(varargin(1:end-1));
+  end
+
+  % find dimensions that were expanded, skip others
+  nonsingleton_rep_dims = find(repelem_sz ~=1);
+  for dim = nonsingleton_rep_dims
+    dy_sz = size(dy);
+    % split the dimension that was repeated
+    split_sz = [dy_sz(1:dim-1),repelem_sz(dim),...
+      dy_sz(dim)/repelem_sz(dim),dy_sz(dim+1:end)];
+    % new_sz removes summed dimension
+    new_sz = [dy_sz(1:dim-1),dy_sz(dim)/repelem_sz(dim),dy_sz(dim+1:end)];
+    % sum the repeated elements
+    dy = reshape(sum(reshape(dy,split_sz),dim),new_sz);
+  end
+  dx = dy;
+end


### PR DESCRIPTION
Overloads repelem and shiftdim. repelem can be useful for unpooling layers. 
Also adds complex number support for abs_der, which is the most common complex nonlinearity. Unit tests for grad checking can be found [here](https://github.com/ryanwebster90/autonn-contrib-testsuite/tree/master/derivatives). 