### PR TITLE
precompute deriv deletion

### DIFF
--- a/matlab/@Net/Net.m
+++ b/matlab/@Net/Net.m
@@ -46,11 +46,11 @@ classdef Net < handle
     gpu = false  % whether the network is in GPU or CPU mode
     isGpuVar = []  % whether each variable or derivative can be on the GPU
     parameterServer = []  % ParameterServer object, accumulates parameter derivatives across GPUs
+    conserveMemory = false % Delete intermediate derivatives on backward pass
   end
   properties (SetAccess = public, GetAccess = public)
     meta = []  % optional meta properties
     diagnostics = []  % list of diagnosed vars (see Net.plotDiagnostics)
-    conserveMemory = false % Delete intermediate derivatives on backward pass
   end
 
   methods (Access = private)

--- a/matlab/@Net/Net.m
+++ b/matlab/@Net/Net.m
@@ -50,7 +50,7 @@ classdef Net < handle
   properties (SetAccess = public, GetAccess = public)
     meta = []  % optional meta properties
     diagnostics = []  % list of diagnosed vars (see Net.plotDiagnostics)
-    conserveMemory = 0
+    conserveMemory = false % Delete intermediate derivatives on backward pass
   end
 
   methods (Access = private)

--- a/matlab/@Net/eval.m
+++ b/matlab/@Net/eval.m
@@ -166,13 +166,10 @@ function eval(net, inputs, mode, derOutput, accumulateParamDers)
         end
       end
       
-      % remove derivatives (even input vars)
-      % as they are no longer used in the network
-    if conserveMemory
-        idx = ~mod(layer.inputVars,2);
-        vars(layer.inputVars(idx)) = {[]};
-    end
-
+      % remove derivatives that are no longer needed
+      if conserveMemory
+        vars(layer.deleteVars) = {[]};
+      end
     end
   end
 


### PR DESCRIPTION
Precomputes derivative deletion and fixes interaction with short circuit layers.

NOTE: temporary solution until #13 is merged, which does this and more. See discussion #12